### PR TITLE
Fix messages data

### DIFF
--- a/models/division.go
+++ b/models/division.go
@@ -1,9 +1,10 @@
 package models
 
 import (
+	"treehole_next/utils"
+
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
-	"treehole_next/utils"
 )
 
 type Division struct {
@@ -18,8 +19,8 @@ type Division struct {
 type Divisions []*Division
 
 func (divisions Divisions) Preprocess(c *fiber.Ctx) error {
-	for _, d := range divisions {
-		err := d.Preprocess(c)
+	for i := 0; i < len(divisions); i++ {
+		err := divisions[i].Preprocess(c)
 		if err != nil {
 			return err
 		}

--- a/models/notification.go
+++ b/models/notification.go
@@ -85,12 +85,12 @@ func (messages Messages) Merge(newMessage Message) Messages {
 	new, _ := newMessage["recipients"].([]int)
 	for _, message := range messages {
 		old, _ := message["recipients"].([]int)
-		for id, r2 := range new {
-			for _, r1 := range old {
+		for _, r1 := range old {
+			for id, r2 := range new {
 				if r1 == r2 {
 					new = append(new[:id], new[id+1:]...)
+					break
 				}
-				break
 			}
 		}
 		if len(new) == 0 {

--- a/models/report.go
+++ b/models/report.go
@@ -98,6 +98,10 @@ func (report *Report) AfterUpdate(tx *gorm.DB) (err error) {
 var adminCounter = new(int32)
 
 func (report *Report) SendCreate(tx *gorm.DB) error {
+	if len(adminList) == 0 {
+		return nil
+	}
+
 	// get counter
 	currentCounter := atomic.AddInt32(adminCounter, 1)
 	result := atomic.CompareAndSwapInt32(adminCounter, int32(len(adminList)), 0)


### PR DESCRIPTION
【通知】notification的有一些问题，现在favorite reply mention是三条message，但是可能会发给同一个人，会导致一个人受到三条内容相同的信息。你看树洞这里发送请求能不能改成，对于一个modify或者create操作仅发送一条message，然后发送请求的请求体里设定好每一个用户组发送的信息。

【解决方案】将CreateFloor时发送的消息进行用户合并，按Reply>Mention>Favorite优先级。如果用户出现在高优先级的消息中，则不会出现在低优先级的消息中。