### PR TITLE
存储管理员操作记录

### DIFF
--- a/apis/division/apis.go
+++ b/apis/division/apis.go
@@ -122,6 +122,8 @@ func ModifyDivision(c *fiber.Ctx) error {
 
 	MyLog("Division", "Modify", division.ID, userID, RoleAdmin)
 
+	CreateAdminLog(AdminLogTypeDivision, userID, body)
+
 	// refresh cache. here should not use `go refreshCache`
 	err = refreshCache(c)
 	if err != nil {

--- a/apis/hole/apis.go
+++ b/apis/hole/apis.go
@@ -435,6 +435,10 @@ func ModifyHole(c *fiber.Ctx) error {
 			if err != nil {
 				return err
 			}
+
+			if user.IsAdmin {
+				CreateAdminLog(AdminLogTypeHole, user.ID, body)
+			}
 		}
 		return nil
 	})

--- a/apis/message/apis.go
+++ b/apis/message/apis.go
@@ -93,6 +93,8 @@ func SendMail(c *fiber.Ctx) error {
 		return err
 	}
 
+	CreateAdminLog(AdminLogTypeMessage, user.ID, body)
+
 	return Serialize(c.Status(201), &message)
 }
 

--- a/models/admin_log.go
+++ b/models/admin_log.go
@@ -1,0 +1,30 @@
+package models
+
+import "time"
+
+type AdminLog struct {
+	ID        int `gorm:"primaryKey"`
+	CreatedAt time.Time
+	Type      AdminLogType `gorm:"size:16;not null"`
+	UserID    int          `gorm:"not null"`
+	Data      any          `gorm:"serializer:json"`
+}
+
+type AdminLogType string
+
+const (
+	AdminLogTypeHole     AdminLogType = "edit_hole"
+	AdminLogTypeDivision AdminLogType = "edit_division"
+	AdminLogTypeMessage  AdminLogType = "send_message"
+)
+
+// CreateAdminLog
+// save admin edit log for audit purpose
+func CreateAdminLog(logType AdminLogType, userID int, data any) {
+	log := AdminLog{
+		Type:   logType,
+		UserID: userID,
+		Data:   data,
+	}
+	DB.Create(&log) // omit error
+}

--- a/models/init.go
+++ b/models/init.go
@@ -149,6 +149,7 @@ func InitDB() {
 		&Message{},
 		&FloorHistory{},
 		&UserSubscription{},
+		&AdminLog{},
 	)
 	if err != nil {
 		log.Fatal().Err(err).Send()


### PR DESCRIPTION
将管理员操作记录（包括对Hole, Division的修改以及发送站内信）存储到数据库中，并通过SQL View开放给内部人员查看。