### PR TITLE
fix: typo of subscriptions routes

### DIFF
--- a/apis/subscription/routes.go
+++ b/apis/subscription/routes.go
@@ -5,5 +5,6 @@ import "github.com/gofiber/fiber/v2"
 func RegisterRoutes(app fiber.Router) {
 	app.Get("/users/subscriptions", ListSubscriptions)
 	app.Post("/users/subscriptions", AddSubscription)
+	app.Delete("/users/subscriptions", DeleteSubscription)
 	app.Delete("/users/subscription", DeleteSubscription)
 }


### PR DESCRIPTION
flutter用的subscriptions，swift用的subscription
暂时二者都保留，后续swift更新到subscriptions，再删除subscription