### PR TITLE
change: clean leading quote from notification message

### DIFF
--- a/models/floor.go
+++ b/models/floor.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"time"
+	"regexp"
 	"treehole_next/utils/sensitive"
 
 	"github.com/opentreehole/go-common"
@@ -461,6 +462,14 @@ func (floor *Floor) ModifyLike(tx *gorm.DB, userID int, likeOption int8) (err er
 Send Notifications
 ******************/
 
+func cleanNotificationDescription(content string) string {
+    // Remove floor id pattern at the start of the string
+    if re := regexp.MustCompile(`^##\d+\n`); re.MatchString(content) {
+        return re.ReplaceAllString(content, "")
+    }
+    return content
+}
+
 func (floor *Floor) SendSubscription(tx *gorm.DB) Notification {
 	// get recipients
 	var tmpIDs []int
@@ -481,7 +490,7 @@ func (floor *Floor) SendSubscription(tx *gorm.DB) Notification {
 	message := Notification{
 		Data:        floor,
 		Recipients:  userIDs,
-		Description: floor.Content,
+		Description: cleanNotificationDescription(floor.Content),
 		Title:       "您关注的帖子有新回复",
 		Type:        MessageTypeFavorite,
 		URL:         fmt.Sprintf("/api/floors/%d", floor.ID),
@@ -508,7 +517,7 @@ func (floor *Floor) SendReply(tx *gorm.DB) Notification {
 	message := Notification{
 		Data:        floor,
 		Recipients:  userIDs,
-		Description: floor.Content,
+		Description: cleanNotificationDescription(floor.Content),
 		Title:       "您的内容有新回复",
 		Type:        MessageTypeReply,
 		URL:         fmt.Sprintf("/api/floors/%d", floor.ID),
@@ -533,7 +542,7 @@ func (floor *Floor) SendMention(_ *gorm.DB) Notification {
 	message := Notification{
 		Data:        floor,
 		Recipients:  userIDs,
-		Description: floor.Content,
+		Description: cleanNotificationDescription(floor.Content),
 		Title:       "您的内容被引用了",
 		Type:        MessageTypeMention,
 		URL:         fmt.Sprintf("/api/floors/%d", floor.ID),
@@ -550,7 +559,7 @@ func (floor *Floor) SendModify(_ *gorm.DB) error {
 	message := Notification{
 		Data:        floor,
 		Recipients:  userIDs,
-		Description: floor.Content,
+		Description: cleanNotificationDescription(floor.Content),
 		Title:       "您的内容被管理员修改了",
 		Type:        MessageTypeModify,
 		URL:         fmt.Sprintf("/api/floors/%d", floor.ID),

--- a/models/floor.go
+++ b/models/floor.go
@@ -463,11 +463,15 @@ Send Notifications
 ******************/
 
 func cleanNotificationDescription(content string) string {
-    // Remove floor id pattern at the start of the string
-    if re := regexp.MustCompile(`^##\d+\n`); re.MatchString(content) {
-        return re.ReplaceAllString(content, "")
-    }
-    return content
+	// Remove "##<number>\n" prefix
+	content = regexp.MustCompile(`^##\d+\n`).ReplaceAllString(content, "")
+
+	// Replace formulas, stickers, and images
+	content = regexp.MustCompile(`\${1,2}.*?\${1,2}`).ReplaceAllString(content, "[公式]")
+	content = regexp.MustCompile(`!\[\]\(dx_\S+\)`).ReplaceAllString(content, "[表情]")
+	content = regexp.MustCompile(`!\[.*?\]\(.*?\)`).ReplaceAllString(content, "[图片]")
+	
+	return content
 }
 
 func (floor *Floor) SendSubscription(tx *gorm.DB) Notification {


### PR DESCRIPTION
This PR modifies the content of notifications description to remove the quote at the beginning. It makes notification previews easier to read.

Please review carefully since I'm not familiar with the language.