### PR TITLE
resolves issue#188

### DIFF
--- a/models/hole.go
+++ b/models/hole.go
@@ -369,7 +369,7 @@ func (hole *Hole) SetHoleFloor() {
 			hole.HoleFloor.Floors = hole.Floors[0 : holeFloorSize-1]
 		}
 	} else if len(hole.HoleFloor.Floors) != 0 {
-		holeFloorSize := len(hole.Floors)
+		holeFloorSize := len(hole.HoleFloor.Floors)
 
 		hole.HoleFloor.FirstFloor = hole.HoleFloor.Floors[0]
 		hole.HoleFloor.LastFloor = hole.HoleFloor.Floors[holeFloorSize-1]


### PR DESCRIPTION
背景：对于新发布的帖子（不包括楼层），在过审时能使其出现在列表顶部。
修改：对apis\floor\apis.go中的ModifyFloorSensitive函数进行了修改。当首层过审时，将该hole的updated_at和created_at字段更新为当前时间。
测试：本地测试可以实现此功能。