### PR TITLE
feat(search): added highlighting for floor search api

### DIFF
--- a/models/elastic.go
+++ b/models/elastic.go
@@ -241,7 +241,13 @@ func Search(c *fiber.Ctx, keyword string, size, offset int, accurate bool, start
 		}
 		floorIDs[i] = id
 		if hit.Highlight != nil {
-			if fragments, ok := hit.Highlight["content"]; ok {
+			var fragments []string
+			if f, ok := hit.Highlight["content"]; ok && len(f) > 0 {
+				fragments = f
+			} else if f, ok := hit.Highlight["content.ik_smart"]; ok && len(f) > 0 {
+				fragments = f
+			}
+			if len(fragments) > 0 {
 				highlightedContents[id] = fragments[0]
 			}
 		}
@@ -275,7 +281,11 @@ func Search(c *fiber.Ctx, keyword string, size, offset int, accurate bool, start
 		if floor.Sensitive() && !floor.Deleted && !floor.IsMe {
 			highlightedContent = floor.Content
 		} else {
-			highlightedContent = highlightedContents[floor.ID]
+			if hc, ok := highlightedContents[floor.ID]; ok {
+				highlightedContent = hc
+			} else {
+				highlightedContent = floor.Content
+			}
 		}
 		highlightedFloors[i] = &HighlightedFloor{
 			Floor:              floor,


### PR DESCRIPTION
resolve #159

- `/api/floors/search`现在多返回一个字段`highlighted_content`，用`<em></em>`包裹`content`中的关键词
- 默认让elasticsearch进行高亮（`Search`），如果elasticsearch不可用（`SearchOld`），执行简单的字符串匹配
- 只是增加字段，应该不影响现有的前端（？）