### PR TITLE
feat(floor): add surroundings API for lazy loading by ranking

### DIFF
--- a/apis/floor/apis.go
+++ b/apis/floor/apis.go
@@ -153,6 +153,55 @@ func GetFloor(c *fiber.Ctx) (err error) {
 	return Serialize(c, &floor)
 }
 
+// GetFloorSurroundings
+//
+// @Summary Get Surrounding Floors
+// @Description 获取指定楼层前后各 size 个楼层，用于跳转定位
+// @Tags Floor
+// @Produce application/json
+// @Router /floors/{id}/surroundings [get]
+// @Param id path int true "floor id"
+// @Param size query int false "上下各加载的楼层数" default(10)
+// @Success 200 {array} Floor
+func GetFloorSurroundings(c *fiber.Ctx) error {
+	floorID, err := c.ParamsInt("id")
+	if err != nil {
+		return err
+	}
+
+	var query SurroundingModel
+	err = common.ValidateQuery(c, &query)
+	if err != nil {
+		return err
+	}
+
+	// get target floor's hole_id and ranking
+	var target Floor
+	err = DB.Select("hole_id", "ranking").First(&target, floorID).Error
+	if err != nil {
+		return err
+	}
+
+	// load floors within ranking range
+	var floors Floors
+	querySet, err := MakeFloorQuerySet(c)
+	if err != nil {
+		return err
+	}
+	err = querySet.
+		Where("hole_id = ? AND ranking BETWEEN ? AND ?",
+			target.HoleID,
+			target.Ranking-query.Size,
+			target.Ranking+query.Size).
+		Order("ranking ASC").
+		Find(&floors).Error
+	if err != nil {
+		return err
+	}
+
+	return Serialize(c, &floors)
+}
+
 // CreateFloor
 //
 // @Summary Create A Floor

--- a/apis/floor/routes.go
+++ b/apis/floor/routes.go
@@ -13,6 +13,7 @@ func RegisterRoutes(app fiber.Router) {
 	app.Get("/holes/:id<int>/floors", ListFloorsInAHole)
 	app.Get("/floors", ListFloorsOld)
 	app.Get("/floors/:id<int>", GetFloor)
+	app.Get("/floors/:id<int>/surroundings", GetFloorSurroundings)
 	app.Post("/holes/:id<int>/floors", utils.MiddlewareHasAnsweredQuestions, CreateFloor)
 	app.Post("/floors", utils.MiddlewareHasAnsweredQuestions, CreateFloorOld)
 	app.Put("/floors/:id<int>", ModifyFloor)

--- a/apis/floor/schemas.go
+++ b/apis/floor/schemas.go
@@ -22,6 +22,10 @@ type ListOldModel struct {
 	Search string `query:"s"           json:"s"`
 }
 
+type SurroundingModel struct {
+	Size int `json:"size" query:"size" default:"10" validate:"min=1,max=50"`
+}
+
 type CreateModel struct {
 	Content string `json:"content" validate:"required"`
 	// Admin and Operator only

--- a/tests/floor_test.go
+++ b/tests/floor_test.go
@@ -221,3 +221,32 @@ func TestDeleteFloor(t *testing.T) {
 	DB.Where("hole_id = ?", hole.ID).Offset(1).First(&floor)
 	testAPI(t, "delete", "/api/floors/"+strconv.Itoa(floor.ID), 200, data)
 }
+
+func TestGetFloorSurroundings(t *testing.T) {
+	// division 7 的第一个 hole 有 50 个 floor (ranking 0-49)
+	var hole Hole
+	DB.Where("division_id = ?", 7).First(&hole)
+
+	// 取中间位置的 floor
+	var midFloor Floor
+	DB.Where("hole_id = ? AND ranking = ?", hole.ID, 25).First(&midFloor)
+
+	// 默认 size=10，应返回 ranking 15-35 共 21 个
+	var floors Floors
+	testAPIModel(t, "get", "/api/floors/"+strconv.Itoa(midFloor.ID)+"/surroundings", 200, &floors)
+	assert.EqualValues(t, 21, len(floors))
+
+	// 自定义 size=5，应返回 ranking 20-30 共 11 个
+	data := Map{"size": 5}
+	testAPIModelWithQuery(t, "get", "/api/floors/"+strconv.Itoa(midFloor.ID)+"/surroundings", 200, &floors, data)
+	assert.EqualValues(t, 11, len(floors))
+
+	// 边界：第一个 floor (ranking=0), size=10 → ranking 0-10 共 11 个
+	var firstFloor Floor
+	DB.Where("hole_id = ? AND ranking = ?", hole.ID, 0).First(&firstFloor)
+	testAPIModel(t, "get", "/api/floors/"+strconv.Itoa(firstFloor.ID)+"/surroundings", 200, &floors)
+	assert.EqualValues(t, 11, len(floors))
+
+	// 404
+	testCommon(t, "get", "/api/floors/"+strconv.Itoa(largeInt)+"/surroundings", 404)
+}


### PR DESCRIPTION
## Summary

新增 `GET /floors/{id}/surroundings?size=10` 接口，支持按楼层位置懒加载周围楼层。Closes #67

**问题**：前端跳转到任意楼层时需要加载整个洞的所有 floor，高回复数的洞性能差。

**方案**：根据目标 floor 的 `ranking`，加载其前后各 `size` 个楼层（默认 10），返回最多 `2 * size + 1` 个 floor。利用已有的 `(hole_id, ranking)` 复合唯一索引，两次查询完成：

1. 由 floor ID 查出 `hole_id` 和 `ranking`
2. `ranking BETWEEN` 范围查询加载周围楼层

## 改动

- `apis/floor/schemas.go` — 新增 `SurroundingModel`（size 参数，默认 10，最大 50）
- `apis/floor/apis.go` — 新增 `GetFloorSurroundings` handler
- `apis/floor/routes.go` — 注册 `GET /floors/:id/surroundings`
- `tests/floor_test.go` — 新增 `TestGetFloorSurroundings`（中间位置、自定义 size、边界、404）

## 使用示例

```
GET /api/floors/12345/surroundings        → 返回 ranking ±10 范围内的楼层
GET /api/floors/12345/surroundings?size=5  → 返回 ranking ±5 范围内的楼层
```
