### PR TITLE
fix: honor OpenSensitiveCheck

### DIFF
--- a/utils/sensitive/api.go
+++ b/utils/sensitive/api.go
@@ -74,6 +74,10 @@ func CheckSensitive(params ParamsForCheck) (resp *ResponseForCheck, err error) {
 		ev.Msg("CheckSensitive completed")
 	}()
 
+	if !config.Config.OpenSensitiveCheck {
+		return &ResponseForCheck{Pass: true}, nil
+	}
+
 	images, clearContent, err := findImagesInMarkdownContent(params.Content)
 	if err != nil {
 		return nil, err

--- a/utils/sensitive/api_test.go
+++ b/utils/sensitive/api_test.go
@@ -1,0 +1,36 @@
+package sensitive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"treehole_next/config"
+)
+
+func TestCheckSensitiveSkipsRemoteCheckWhenDisabled(t *testing.T) {
+	oldOpenSensitiveCheck := config.Config.OpenSensitiveCheck
+	config.Config.OpenSensitiveCheck = false
+	t.Cleanup(func() {
+		config.Config.OpenSensitiveCheck = oldOpenSensitiveCheck
+	})
+
+	var (
+		resp *ResponseForCheck
+		err  error
+	)
+
+	require.NotPanics(t, func() {
+		resp, err = CheckSensitive(ParamsForCheck{
+			Content:  "plain text",
+			Id:       1,
+			TypeName: TypeHole,
+		})
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Pass)
+	assert.Empty(t, resp.Detail)
+	assert.Nil(t, resp.Labels)
+}


### PR DESCRIPTION
fix #221 

# Summary:
在非生产环境的测试场景下，设置Config.OpenSensitiveCheck时，可以跳过敏感词检查，避开网易易盾审核凭据引发的panic

# Verification
``` shell
go test ./utils/sensitive -run TestCheckSensitiveSkipsRemoteCheckWhenDisabled -count=1
``` 