### PR TITLE
fix: allow banning users from deleted holes

### DIFF
--- a/apis/penalty/api.go
+++ b/apis/penalty/api.go
@@ -66,7 +66,7 @@ func BanUser(c *fiber.Ctx) error {
 	}
 
 	var hole Hole
-	err = DB.Take(&hole, floor.HoleID).Error
+	err = DB.Unscoped().Select("id", "division_id").Take(&hole, floor.HoleID).Error
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
修复了“帖子删了以后没办法封禁里面的用户”的问题

**问题**：`BanUser`虽然能正常查到目标楼层，但随后会用GORM默认查询去读取对应的`Hole`，以获取`division_id`。由于`Hole`使用了`gorm.DeletedAt`，软删除的帖子会被默认过滤掉，导致封禁流程中断。

**方案**：把这一步查询改为`Unscoped()`，并且只读取创建处罚记录所需的`id`和`division_id`。本地测试通过。